### PR TITLE
Support for vars in custom component template

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -75,6 +75,11 @@ function allPaths(app) {
             let component = req.path.replace(compPath + '/', '');
             let data = getData(component);
             template = getComponentIndex(component, data);
+
+            if (template) {
+                template = eval('`'+template+'`');
+            }
+
             if(!template) {
                 template = getTemplate(component, data);
                 snippet = getSnippet(component);


### PR DESCRIPTION
This is an idea I had. Right now when working with custom templates you have to define everything statically, loosing values such as component name, data etc.

The core problem is that templates are treated as strings, not string literals, and there are no pretty way of doing this, besides using... `eval()`. And thats what I did.

By converting the template to a string literal I can use the following template.

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <title>React testing ground</title>
    <script src="${publicPath}js/vendor.js"></script>
<link rel="stylesheet" href="${publicPath}css/index.css">
</head>
<body>
    <div id="${container}"></div>
    <script src="${publicPath}js/index.js"></script>

    <script>
    var data = ${JSON.stringify(data)};

    if (window.store) {
        data.store = window.store;
    }
    </script>

    <script>
        ReactDOM.render(React.createElement(Components.${component}, data), document.getElementById("${container}"));
    </script>
</body>
</html>
```